### PR TITLE
Fix C string function and add example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,10 +70,22 @@ pub fn yyid_string() -> String {
 }
 
 /// Creates a new random YYID as a C-compatible char*
+///
+/// ### Example
+/// ```rust
+/// use yyid::yyid_c_string;
+/// use std::ffi::CString;
+///
+/// let yyid_c_string_ptr = yyid_c_string();
+/// unsafe {
+///     assert_eq!(b'-',  *yyid_c_string_ptr.offset(8) as u8);
+///     let _ = CString::from_raw(yyid_c_string_ptr);
+/// }
+/// ```
 #[no_mangle]
-pub extern "C" fn yyid_c_string() -> *const c_char {
+pub extern "C" fn yyid_c_string() -> *mut c_char {
     let yyid = YYID::new().to_hyphenated_string();
-    let c_yyid = CString::new(yyid).unwrap();
+    let c_yyid = CString::new(yyid).expect("CString::new failed");
     c_yyid.into_raw()
 }
 


### PR DESCRIPTION
Return type slightly changed from `*const c_char` (i8) to `*mut c_char`,
so it is now more aligned with the CString return type and can also
be consumed with `CString::from_raw(ptr)` without issues.

Furthermore:
Fixes #4

Future:
Potentially remove such helper functions and leave it to the
library users to cross the language boundaries on their own terms.